### PR TITLE
Camanjs tweaks

### DIFF
--- a/caman.js
+++ b/caman.js
@@ -88,20 +88,13 @@
 
           img.src = options.src; 
 
+          img.onload = function() {
+             imageReady.call(that);
+          };
           if ( !Caman.ready ) {
             document.addEventListener("DOMContentLoaded", function() {
               Caman.ready = true;
-              
-              img.onload = function() {
-                  imageReady.call(that);  
-              };
-            }, false);        
-          } else {
-
-            img.onload = function() {
-              imageReady.call(that);  
-            };
-          }
+	  }
         } else {
           // Handle Caman('#index')
           return Caman.store[options];
@@ -665,7 +658,7 @@
                   "processFn" : self.queue[next].process.toString(),
                   "processFnName" : self.queue[next].process.name,
                   "adjust": self.queue[next].adjust
-                });                  
+                });
               }
                             
               self.inProcess = false;
@@ -692,7 +685,7 @@
           "processFn" : processFn.toString(),
           "processFnName" : processFn.name,
           "adjust": adjust
-        });      
+        });
       }
         
 
@@ -752,8 +745,7 @@ onmessage = function( event ) {
   // TODO: add rest of data object
   postMessage({
     "processFnName": data.processFnName, 
-    "pixelData" : data.pixelData,
-    "data" : data
+    "pixelData" : data.pixelData
   });
 };
 // WorkerGlobalScope //


### PR DESCRIPTION
Hi,

had to make some minor adjustments to have your library work with Opera, hope it is of some use --
- the registration of the onload handler for the image was tangled up with
  DOMContentLoaded which ran the risk of the image loading before DOMContentLoaded
  was delivered (=> no onload firing.)
- the use of .postMessage() inside the Worker passed both a 'data' value and the ImageData
  it contains. That is skating on thin ice wrt what the "structured cloning" algorithm supports
  (or, at least used to until v. recently -- the spec now fully admits cloning shared & cyclic values.)
  In any case, passing back the 'data' portion doesn't seem warranted & so removed.

Cool library (and implementation); just want to make sure it runs well on a cool browser ;-)
