### PR TITLE
support loading image from buffer in Node

### DIFF
--- a/dist/caman.full.js
+++ b/dist/caman.full.js
@@ -303,7 +303,9 @@
       var img,
         _this = this;
       img = new Image();
-      file = fs.realpathSync(file);
+      if (typeof file === "string") {
+        file = fs.realpathSync(file);
+      }
       img.onload = function() {
         var context;
         _this.canvasID = Util.uniqid.get();

--- a/dist/caman.js
+++ b/dist/caman.js
@@ -303,7 +303,9 @@
       var img,
         _this = this;
       img = new Image();
-      file = fs.realpathSync(file);
+      if (typeof file === "string") {
+        file = fs.realpathSync(file);
+      }
       img.onload = function() {
         var context;
         _this.canvasID = Util.uniqid.get();


### PR DESCRIPTION
loadNode assumes first argument to Caman() is a string/path. Can we make it support Buffer as well? The underlying node-canvas supports this: https://github.com/LearnBoost/node-canvas#imagesrcbuffer

I want to be able to do something like this:

```
<mongo|redis|whatever>.getfile(query, function(err, buffer) {
    Canvas(buffer, function() {
        ...
    })
})
```

Comments on commit welcome, just made it as simple as possible
