### PR TITLE
Added CORS support to CamanInstance.canvasLoaded()

### DIFF
--- a/src/core/camaninstance.coffee
+++ b/src/core/camaninstance.coffee
@@ -114,6 +114,7 @@ class CamanInstance
       throw "Given element ID isn't a canvas: #{id}"
     
     if url?
+      crossOrigin = if IO.isRemote(@image.src) then @image.crossOrigin if @image.crossOrigin else "anonymous"
       @image = document.createElement 'img'
       @image.onload = => @finishInit callback
       
@@ -123,7 +124,8 @@ class CamanInstance
       @options =
         canvas: canvas.id
         image: url
-        
+       
+      @image.crossOrigin = crossOrigin if crossOrigin 
       @image.src = if proxyURL then proxyURL else url
     else
       @finishInit callback


### PR DESCRIPTION
I think my previous pull was automatically closed when I reset my branch to HEAD. I guess the proper workflow is to branch again, merge new branch into old branch and push -f origin branch?

After implementing and refactoring a few times I think I have it down properly. Let me know if this is what you meant.

I didn't write tests, but I tried reverting a CamanInstance of three separate images:

same domain, no crossorigin attribute
remote domain with no crossorigin attribute defaulted to "anonymous"
remote domain with a crossorigin 'something' is recreated with 'crossorigin="something"'

Let me know what you think.
