### PR TITLE
The get paramater in the php proxy is not the same that the js

### DIFF
--- a/proxies/caman_proxy.php
+++ b/proxies/caman_proxy.php
@@ -3,12 +3,14 @@
 // end in an image file extension. E.g. through another proxy of kinds.
 define('ALLOW_NO_EXT', false);
 
-if (!$_GET['url']) {
+$proxyParam = 'camanProxyUrl';
+
+if (!$_GET[$proxyParam]) {
   exit;
 }
 
 // Grab the URL
-$url = trim(urldecode($_GET['url']));
+$url = trim(urldecode($_GET[$proxyParam]));
 
 $urlinfo = parse_url($url, PHP_URL_PATH);
 $ext = array_reverse(explode(".", $urlinfo));


### PR DESCRIPTION
In the JS/Coffescript the variable @proxyParam is "camanProxyUrl" by default, but in the php proxy is still "url". With the default code the proxy doesnt run.

I changed the default value and create a new variable to make easier the change.
