### PR TITLE
domainRegex not matching all domains

### DIFF
--- a/src/core/io.coffee
+++ b/src/core/io.coffee
@@ -1,7 +1,7 @@
 # Various I/O based operations
 class Caman.IO
   # Used for parsing image URLs for domain names.
-  @domainRegex: /(?:(?:http|https):\/\/)((?:\w+)\.(?:(?:\w|\.)+))/
+  @domainRegex: /^https?\:\/\/([^\/:?#]+)(?:[\/:?#]|$)/i
 
   # Is the given URL remote?
   # If a cross-origin setting is set, we assume you have CORS


### PR DESCRIPTION
the current Regex does only match parts of domains like "de.staging.my-cool-service.com". ('de.staging.my')
Then the IO.isURLRemote check returns true when it should not. (leading to images being loaded by proxy)
this Regex worked for me.
