### PR TITLE
'Attr.nodeValue' is deprecated

### DIFF
--- a/src/core/util.coffee
+++ b/src/core/util.coffee
@@ -33,7 +33,7 @@ class Util
   @copyAttributes: (from, to, opts={}) ->
     for attr in from.attributes
       continue if opts.except? and attr.nodeName in opts.except
-      to.setAttribute(attr.nodeName, attr.nodeValue)
+      to.setAttribute(attr.nodeName, attr.value)
 
   # Support for browsers that don't know Uint8Array (such as IE9)
   @dataArray: (length = 0) ->


### PR DESCRIPTION
Chrome (Version 40.0.2214.111 m) gives a warning about nodeValue:
```
'Attr.nodeValue' is deprecated. Please use 'value' instead.
```

I wasn't able to build until I bumped karma up to version 0.12, and my current machine isn't setup up correctly to build the docs properly, so I only committed the source change.