### PR TITLE
fix toImage bug and split tests based on browser requirement

### DIFF
--- a/dist/caman.full.js
+++ b/dist/caman.full.js
@@ -1562,7 +1562,7 @@
 
   Caman.prototype.toImage = function(type) {
     var img;
-    img = new Image();
+    img = new window.Image();
     img.src = this.toBase64(type);
     img.width = this.dimensions.width;
     img.height = this.dimensions.height;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function(config) {
       'test/ext/test-loader.js',
       'test/ext/grey.js',
       'dist/caman.full.js',
-      'test/unit/*.coffee',
+      'test/unit/**/*.coffee',
       {pattern: 'test/ext/grey.png', watched: false, included: false}
     ],
 

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "karma-mocha": "*"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --compilers coffee:coffee-script --reporter spec --globals Caman ./test/unit/*.coffee && ./node_modules/.bin/karma start --single-run --browsers Firefox",
+    "test": "./node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register --reporter spec --globals Caman ./test/unit/*.coffee && ./node_modules/.bin/karma start --single-run --browsers Firefox",
+    "test-local": "./node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register --reporter spec --globals Caman ./test/unit/*.coffee",
+    "test-browser": "./node_modules/.bin/karma start --single-run --browsers Firefox",
     "examples": "./node_modules/servedir/bin/servedir",
     "docs": "codo",
     "docs-server": "codo --server"

--- a/test/unit/browser/io.coffee
+++ b/test/unit/browser/io.coffee
@@ -1,0 +1,17 @@
+if exports?
+  {Caman}   = require "../../dist/caman.full"
+  {assert}  = require 'chai'
+  {greyImage, greyPath, rgbData}   = require '../ext/grey'
+
+describe "io", ->
+  it "should generate image tag", (done) ->
+    Caman greyImage, ->
+      img = @toImage()
+      assert img.src && img.src.match(/^data:image\/png;base64/)
+      done()
+
+  it "should generate base64 data url", (done) ->
+    Caman greyImage, ->
+      dataURL = @toBase64()
+      assert dataURL.match(/^data:image\/png;base64/)
+      done()


### PR DESCRIPTION
1. Change test command from `/mocha --complier coffee:coffee-script` to `coffee:coffee-script/register`
2. Splitting tests into two sets one requires browser and one without (so stuff that requires dom api can be tested)
3. Fix name conflicts caused by assignment `Image = canvas.Image()` vs `new Image()` in `toImage() function`
