### PR TITLE
Improved the exposure filter by changing the curve formula

### DIFF
--- a/src/lib/filters.coffee
+++ b/src/lib/filters.coffee
@@ -371,11 +371,9 @@ Filter.register "curves", (chans, cps...) ->
 Filter.register "exposure", (adjust) ->
   p = Math.abs(adjust) / 100
 
-  ctrl1 = [0, 255 * p]
-  ctrl2 = [255 - (255 * p), 255]
-
   if adjust < 0
-    ctrl1 = ctrl1.reverse()
-    ctrl2 = ctrl2.reverse()
+    ctrl = [255 * p, 0]
+  else
+    ctrl = [255 * (1 - p), 255]
 
-  @curves 'rgb', [0, 0], ctrl1, ctrl2, [255, 255]
+  @curves 'rgb', [0, 0], ctrl, [255, 255]


### PR DESCRIPTION
We use Caman.js's Exposure filter every day at GunMemorial.org and I have found that is does not behave as well as the exposure control in photo editing app's like Mac's Preview.app.  Increasing the exposure does not increase the contrast, so blacks became grayish and the image looks washed-out.

In this patch, I changed the curve being used for the exposure filter and now if behaves much better for photographs.  Rather than simply changing the "y-intercept" of the curve, it now changes the slope as well (which changes the contrast). The results look much better to me.

**Please be aware** that I do not have a NPM/CoffeeScript dev environment set up at the moment, so you should compile and test before merging. I tested the curve formula used in the patch by using the curve filter directly in JS, as seen in this commit:

https://github.com/starzia/GunMemorial/commit/8dfa1be02cedae29da772ee93facc7d385786f2d